### PR TITLE
Supported GHC 8.2.1

### DIFF
--- a/geniplate-mirror.cabal
+++ b/geniplate-mirror.cabal
@@ -28,6 +28,6 @@ source-repository head
   location: https://github.com/danr/geniplate
 
 library
-  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.12, mtl
+  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.13, mtl
 
   Exposed-modules:      Data.Generics.Geniplate


### PR DESCRIPTION
I just bumped the upper bound version of template-haskell.

Release a new version after merging this PR, please.