### PR TITLE
Fixed compilation with GHC 8.4.1-alpha1

### DIFF
--- a/geniplate-mirror.cabal
+++ b/geniplate-mirror.cabal
@@ -28,6 +28,6 @@ source-repository head
   location: https://github.com/danr/geniplate
 
 library
-  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.13, mtl
+  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.14, mtl
 
   Exposed-modules:      Data.Generics.Geniplate


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). This PR fix compilation with this version of GHC.
