### PR TITLE
Fixed compilation with GHC 8.6.1

### DIFF
--- a/geniplate-mirror.cabal
+++ b/geniplate-mirror.cabal
@@ -28,6 +28,6 @@ source-repository head
   location: https://github.com/danr/geniplate
 
 library
-  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.14, mtl
+  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.15, mtl
 
   Exposed-modules:      Data.Generics.Geniplate


### PR DESCRIPTION
GHC 8.6.1-alpha2 was [announced](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-July/026776.html). This PR fix the compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/3160.