### PR TITLE
relax version bounds on template-haskell for ghc 8.6

### DIFF
--- a/geniplate-mirror.cabal
+++ b/geniplate-mirror.cabal
@@ -28,6 +28,6 @@ source-repository head
   location: https://github.com/danr/geniplate
 
 library
-  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.14, mtl
+  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.15, mtl
 
   Exposed-modules:      Data.Generics.Geniplate


### PR DESCRIPTION
It builds with stack and allow-newer: true